### PR TITLE
Follow redirects to get downloads working again.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -68,7 +68,7 @@ get_download_file_path() {
 
 get_url_status() {
   local url="$1"
-  local status="$(curl -s -I "$url" | grep 'HTTP/1.1' | awk '{print $2}')"
+  local status="$(curl -s -I -L "$url" | grep 'HTTP/1.1' | awk '{print $2}' | tail -n 1)"
 
   echo "$status"
 }


### PR DESCRIPTION
Your asdf sbt plugin currently gets a 302 redirect from any "https://dl.bintray.com/sbt/native-packages/sbt/${version}/sbt-${version}.tgz" address, and does not follow it, so comparison ```if [[ "x200" == "x$(get_url_status "$baseurl_bintray")" ]]``` always fails. I added option -L to curl (to follow redirects) and ```| tail -n 1)``` in the end of `local_status` so that it returns the last status if there are redirects.