### PR TITLE
Fix Github download link

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -68,7 +68,7 @@ get_download_file_path() {
 
 get_url_status() {
   local url="$1"
-  local status="$(curl -s -I -L "$url" | grep 'HTTP/1.1' | awk '{print $2}' | tail -n 1)"
+  local status="$(curl -s -I -L "$url" | grep 'HTTP' | awk '{print $2}' | tail -n 1)"
 
   echo "$status"
 }


### PR DESCRIPTION
I ran into an issue when running `asdf install sbt 1.5.8` and after some debugging, I realized it was because it was resolving the curl output wrong since my headers were `HTTP/2` instead of `HTTP/1.1`. I think this change should be universal for all machines, but please let me know if this isn't the correct way to resolve this issue. Thanks!