### PR TITLE
Moving binary reposity from Bintray to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Install script was adapted from https://github.com/smashedtoatoms/asdf-scala/blo
 ``` shell
 asdf plugin-add sbt https://github.com/lerencao/asdf-sbt
 asdf list-all sbt
-asdf install sbt 0.13.8
+asdf install sbt 1.8.2
 ```
 To run SBT, you need to have a working Java install (either Oracle's or OpenJDK).

--- a/bin/install
+++ b/bin/install
@@ -68,7 +68,7 @@ get_download_file_path() {
 
 get_url_status() {
   local url="$1"
-  local status="$(curl -s -I -L "$url" | grep 'HTTP/1.1' | awk '{print $2}' | tail -n 1)"
+  local status="$(curl -s -I -L "$url" | grep 'HTTP/2' | awk '{print $2}' | tail -n 1)"
 
   echo "$status"
 }
@@ -76,11 +76,10 @@ get_url_status() {
 get_download_url() {
   local install_type=$1
   local version=$2
-  local baseurl_bintray="https://dl.bintray.com/sbt/native-packages/sbt/${version}/sbt-${version}.tgz"
+  local baseurl_github="https://github.com/sbt/sbt/releases/download/v${version}/sbt-${version}.tgz"
 
-
-  if [[ "x200" == "x$(get_url_status "$baseurl_bintray")" ]]; then
-    echo "$baseurl_bintray"
+  if [[ "x200" == "x$(get_url_status "$baseurl_github")" ]]; then
+    echo "$baseurl_github"
   else
     echo "Distribution file not found. Exiting"
     exit 1

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-curl -s https://dl.bintray.com/sbt/native-packages/sbt/ | \
-    grep 'href=' | \
-    awk -F'>' '{print $3}' | awk -F'<' '{print $1}' | sed -e 's/\///g' | \
-    sed -e 's/\n/ /g' | tr '\n' ' '
+curl -s -H "Accept: application/vnd.github+json" https://api.github.com/repos/sbt/sbt/releases?per_page=100 |
+    grep -e '.*"sbt-.*.tgz"' |
+    cut -d '"' -f 4 |
+    sed -e 's#^sbt-##' -e 's#.tgz$##' |
+    sort --version-sort |
+    xargs echo


### PR DESCRIPTION
It seems that the SBT binaries are no longer available on Bintray but on GitHub now. 

This makes this ASDF plugin unfunctional.

This PR fixes that.