### PR TITLE
fix(): fix download

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -68,8 +68,7 @@ get_download_file_path() {
 
 get_url_status() {
   local url="$1"
-  local status="$(curl -s -I -L "$url" | grep 'HTTP' | awk '{print $2}' | tail -n 1)"
-
+  local status="$(curl --silent --head --location "$url" | grep 'HTTP/2' | awk '{print $2}' | tail -n 1)"
   echo "$status"
 }
 


### PR DESCRIPTION
## Issue

Each attempt to install a version of SBT results in a message of type
> The specified version was not found. Output

This is due to incorrect parsing of the status code returned by `curl`.

## Fix

Improve `curl` status code parsing: move `grep` command from `grep HTTP` to `grep HTTP/2` (because GH is an HTTP2 server).

## Sorry

The issue was provided by [the](https://github.com/lerencao/asdf-sbt/pull/4/commits/ea4a7c0f9defdd20e12f89f76ff03cee396cd304)
My bad. 
